### PR TITLE
feat: improve performance

### DIFF
--- a/blake3.go
+++ b/blake3.go
@@ -45,41 +45,31 @@ func wordsToBytes(words []uint32, bytes []byte) {
 	}
 }
 
-// The g function, split into two parts so that the compiler will inline it.
-func gx(state *[16]uint32, a, b, c, d int, mx uint32) {
-	state[a] += state[b] + mx
-	state[d] = bits.RotateLeft32(state[d]^state[a], -16)
-	state[c] += state[d]
-	state[b] = bits.RotateLeft32(state[b]^state[c], -12)
-}
-
-func gy(state *[16]uint32, a, b, c, d int, my uint32) {
-	state[a] += state[b] + my
-	state[d] = bits.RotateLeft32(state[d]^state[a], -8)
-	state[c] += state[d]
-	state[b] = bits.RotateLeft32(state[b]^state[c], -7)
+// The g function
+func g(a, b, c, d, mx, my uint32) (uint32, uint32, uint32, uint32) {
+	a += b + mx
+	d = bits.RotateLeft32(d^a, -16)
+	c += d
+	b = bits.RotateLeft32(b^c, -12)
+	a += b + my
+	d = bits.RotateLeft32(d^a, -8)
+	c += d
+	b = bits.RotateLeft32(b^c, -7)
+	return a, b, c, d
 }
 
 func round(state *[16]uint32, m *[16]uint32) {
 	// Mix the columns.
-	gx(state, 0, 4, 8, 12, m[0])
-	gy(state, 0, 4, 8, 12, m[1])
-	gx(state, 1, 5, 9, 13, m[2])
-	gy(state, 1, 5, 9, 13, m[3])
-	gx(state, 2, 6, 10, 14, m[4])
-	gy(state, 2, 6, 10, 14, m[5])
-	gx(state, 3, 7, 11, 15, m[6])
-	gy(state, 3, 7, 11, 15, m[7])
+	state[0], state[4], state[8], state[12] = g(state[0], state[4], state[8], state[12], m[0], m[1])
+	state[1], state[5], state[9], state[13] = g(state[1], state[5], state[9], state[13], m[2], m[3])
+	state[2], state[6], state[10], state[14] = g(state[2], state[6], state[10], state[14], m[4], m[5])
+	state[3], state[7], state[11], state[15] = g(state[3], state[7], state[11], state[15], m[6], m[7])
 
 	// Mix the diagonals.
-	gx(state, 0, 5, 10, 15, m[8])
-	gy(state, 0, 5, 10, 15, m[9])
-	gx(state, 1, 6, 11, 12, m[10])
-	gy(state, 1, 6, 11, 12, m[11])
-	gx(state, 2, 7, 8, 13, m[12])
-	gy(state, 2, 7, 8, 13, m[13])
-	gx(state, 3, 4, 9, 14, m[14])
-	gy(state, 3, 4, 9, 14, m[15])
+	state[0], state[5], state[10], state[15] = g(state[0], state[5], state[10], state[15], m[8], m[9])
+	state[1], state[6], state[11], state[12] = g(state[1], state[6], state[11], state[12], m[10], m[11])
+	state[2], state[7], state[8], state[13] = g(state[2], state[7], state[8], state[13], m[12], m[13])
+	state[3], state[4], state[9], state[14] = g(state[3], state[4], state[9], state[14], m[14], m[15])
 }
 
 func permute(m, n *[16]uint32) {

--- a/blake3.go
+++ b/blake3.go
@@ -35,13 +35,13 @@ var iv = [8]uint32{
 
 func bytesToWords(bytes []byte, words []uint32) {
 	for i := range words {
-		words[i] = binary.LittleEndian.Uint32(bytes[i*4:])
+		words[i] = binary.LittleEndian.Uint32(bytes[i*4 : i*4+4 : i*4+4])
 	}
 }
 
 func wordsToBytes(words []uint32, bytes []byte) {
 	for i, w := range words {
-		binary.LittleEndian.PutUint32(bytes[i*4:], w)
+		binary.LittleEndian.PutUint32(bytes[i*4:i*4+4:i*4+4], w)
 	}
 }
 

--- a/blake3.go
+++ b/blake3.go
@@ -82,13 +82,23 @@ func round(state *[16]uint32, m *[16]uint32) {
 	gy(state, 3, 4, 9, 14, m[15])
 }
 
-func permute(m *[16]uint32) {
-	*m = [16]uint32{
-		m[2], m[6], m[3], m[10],
-		m[7], m[0], m[4], m[13],
-		m[1], m[11], m[12], m[5],
-		m[9], m[14], m[15], m[8],
-	}
+func permute(m, n *[16]uint32) {
+	n[0] = m[2]
+	n[1] = m[6]
+	n[2] = m[3]
+	n[3] = m[10]
+	n[4] = m[7]
+	n[5] = m[0]
+	n[6] = m[4]
+	n[7] = m[13]
+	n[8] = m[1]
+	n[9] = m[11]
+	n[10] = m[12]
+	n[11] = m[5]
+	n[12] = m[9]
+	n[13] = m[14]
+	n[14] = m[15]
+	n[15] = m[8]
 }
 
 // A node represents a chunk or parent in the BLAKE3 Merkle tree. In BLAKE3
@@ -121,19 +131,19 @@ func (n node) compress() [16]uint32 {
 		iv[0], iv[1], iv[2], iv[3],
 		uint32(n.counter), uint32(n.counter >> 32), n.blockLen, n.flags,
 	}
-
+	var block2 [16]uint32
 	round(&state, &n.block) // round 1
-	permute(&n.block)
-	round(&state, &n.block) // round 2
-	permute(&n.block)
+	permute(&n.block, &block2)
+	round(&state, &block2) // round 2
+	permute(&block2, &n.block)
 	round(&state, &n.block) // round 3
-	permute(&n.block)
-	round(&state, &n.block) // round 4
-	permute(&n.block)
+	permute(&n.block, &block2)
+	round(&state, &block2) // round 4
+	permute(&block2, &n.block)
 	round(&state, &n.block) // round 5
-	permute(&n.block)
-	round(&state, &n.block) // round 6
-	permute(&n.block)
+	permute(&n.block, &block2)
+	round(&state, &block2) // round 6
+	permute(&block2, &n.block)
 	round(&state, &n.block) // round 7
 
 	for i := range n.cv {

--- a/blake3_test.go
+++ b/blake3_test.go
@@ -190,12 +190,21 @@ func (nopReader) Read(p []byte) (int, error) { return len(p), nil }
 
 func BenchmarkWrite(b *testing.B) {
 	b.ReportAllocs()
-	b.SetBytes(1)
-	io.CopyN(blake3.New(0, nil), nopReader{}, int64(b.N))
+	b.SetBytes(1024)
+
+	h := blake3.New(0, nil)
+	buf := make([]byte, 1024)
+	for i := 0; i < b.N; i++ {
+		_, err := h.Write(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func BenchmarkSum256(b *testing.B) {
 	b.ReportAllocs()
+	b.SetBytes(1024)
 	buf := make([]byte, 1024)
 	for i := 0; i < b.N; i++ {
 		blake3.Sum256(buf)
@@ -204,6 +213,13 @@ func BenchmarkSum256(b *testing.B) {
 
 func BenchmarkXOF(b *testing.B) {
 	b.ReportAllocs()
-	b.SetBytes(1)
-	io.CopyN(ioutil.Discard, blake3.New(0, nil).XOF(), int64(b.N))
+	b.SetBytes(1024)
+	xof := blake3.New(0, nil).XOF()
+	buf := make([]byte, 1024)
+	for i := 0; i < b.N; i++ {
+		_, err := xof.Read(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
* avoid copying on permute.
* add a capacity hint on bytesToWords.
* merge gx and gy into g.
```
name      old time/op    new time/op    delta
Write-4     4.62µs ± 1%    4.04µs ± 0%  -12.61%  (p=0.000 n=43+9)
Sum256-4    4.59µs ± 1%    3.96µs ± 0%  -13.75%  (p=0.000 n=41+9)
XOF-4       4.34µs ± 0%    3.79µs ± 0%  -12.55%  (p=0.000 n=44+9)

name      old speed      new speed      delta
Write-4    221MB/s ± 1%   253MB/s ± 0%  +14.43%  (p=0.000 n=43+9)
Sum256-4   223MB/s ± 1%   259MB/s ± 0%  +15.94%  (p=0.000 n=41+9)
XOF-4      236MB/s ± 0%   270MB/s ± 0%  +14.38%  (p=0.000 n=44+8)

name      old alloc/op   new alloc/op   delta
Write-4      0.00B          0.00B          ~     (all equal)
Sum256-4     0.00B          0.00B          ~     (all equal)
XOF-4        0.00B          0.00B          ~     (all equal)

name      old allocs/op  new allocs/op  delta
Write-4       0.00           0.00          ~     (all equal)
Sum256-4      0.00           0.00          ~     (all equal)
XOF-4         0.00           0.00          ~     (all equal)
```