### PR TITLE
Remove permute() and alternate method of getting g() inlined leads to better performance

### DIFF
--- a/blake3.go
+++ b/blake3.go
@@ -60,37 +60,6 @@ func gy(state *[16]uint32, a, b, c, d int, my uint32) {
 	state[b] = bits.RotateLeft32(state[b]^state[c], -7)
 }
 
-func round(state *[16]uint32, m *[16]uint32) {
-	// Mix the columns.
-	gx(state, 0, 4, 8, 12, m[0])
-	gy(state, 0, 4, 8, 12, m[1])
-	gx(state, 1, 5, 9, 13, m[2])
-	gy(state, 1, 5, 9, 13, m[3])
-	gx(state, 2, 6, 10, 14, m[4])
-	gy(state, 2, 6, 10, 14, m[5])
-	gx(state, 3, 7, 11, 15, m[6])
-	gy(state, 3, 7, 11, 15, m[7])
-
-	// Mix the diagonals.
-	gx(state, 0, 5, 10, 15, m[8])
-	gy(state, 0, 5, 10, 15, m[9])
-	gx(state, 1, 6, 11, 12, m[10])
-	gy(state, 1, 6, 11, 12, m[11])
-	gx(state, 2, 7, 8, 13, m[12])
-	gy(state, 2, 7, 8, 13, m[13])
-	gx(state, 3, 4, 9, 14, m[14])
-	gy(state, 3, 4, 9, 14, m[15])
-}
-
-func permute(m *[16]uint32) {
-	*m = [16]uint32{
-		m[2], m[6], m[3], m[10],
-		m[7], m[0], m[4], m[13],
-		m[1], m[11], m[12], m[5],
-		m[9], m[14], m[15], m[8],
-	}
-}
-
 // A node represents a chunk or parent in the BLAKE3 Merkle tree. In BLAKE3
 // terminology, the elements of the bottom layer (aka "leaves") of the tree are
 // called chunk nodes, and the elements of upper layers (aka "interior nodes")
@@ -122,19 +91,159 @@ func (n node) compress() [16]uint32 {
 		uint32(n.counter), uint32(n.counter >> 32), n.blockLen, n.flags,
 	}
 
-	round(&state, &n.block) // round 1
-	permute(&n.block)
-	round(&state, &n.block) // round 2
-	permute(&n.block)
-	round(&state, &n.block) // round 3
-	permute(&n.block)
-	round(&state, &n.block) // round 4
-	permute(&n.block)
-	round(&state, &n.block) // round 5
-	permute(&n.block)
-	round(&state, &n.block) // round 6
-	permute(&n.block)
-	round(&state, &n.block) // round 7
+	// round1
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[0])
+	gy(&state, 0, 4, 8, 12, n.block[1])
+	gx(&state, 1, 5, 9, 13, n.block[2])
+	gy(&state, 1, 5, 9, 13, n.block[3])
+	gx(&state, 2, 6, 10, 14, n.block[4])
+	gy(&state, 2, 6, 10, 14, n.block[5])
+	gx(&state, 3, 7, 11, 15, n.block[6])
+	gy(&state, 3, 7, 11, 15, n.block[7])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[8])
+	gy(&state, 0, 5, 10, 15, n.block[9])
+	gx(&state, 1, 6, 11, 12, n.block[10])
+	gy(&state, 1, 6, 11, 12, n.block[11])
+	gx(&state, 2, 7, 8, 13, n.block[12])
+	gy(&state, 2, 7, 8, 13, n.block[13])
+	gx(&state, 3, 4, 9, 14, n.block[14])
+	gy(&state, 3, 4, 9, 14, n.block[15])
+
+	// round2
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[2])
+	gy(&state, 0, 4, 8, 12, n.block[6])
+	gx(&state, 1, 5, 9, 13, n.block[3])
+	gy(&state, 1, 5, 9, 13, n.block[10])
+	gx(&state, 2, 6, 10, 14, n.block[7])
+	gy(&state, 2, 6, 10, 14, n.block[0])
+	gx(&state, 3, 7, 11, 15, n.block[4])
+	gy(&state, 3, 7, 11, 15, n.block[13])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[1])
+	gy(&state, 0, 5, 10, 15, n.block[11])
+	gx(&state, 1, 6, 11, 12, n.block[12])
+	gy(&state, 1, 6, 11, 12, n.block[5])
+	gx(&state, 2, 7, 8, 13, n.block[9])
+	gy(&state, 2, 7, 8, 13, n.block[14])
+	gx(&state, 3, 4, 9, 14, n.block[15])
+	gy(&state, 3, 4, 9, 14, n.block[8])
+
+	// round3
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[3])
+	gy(&state, 0, 4, 8, 12, n.block[4])
+	gx(&state, 1, 5, 9, 13, n.block[10])
+	gy(&state, 1, 5, 9, 13, n.block[12])
+	gx(&state, 2, 6, 10, 14, n.block[13])
+	gy(&state, 2, 6, 10, 14, n.block[2])
+	gx(&state, 3, 7, 11, 15, n.block[7])
+	gy(&state, 3, 7, 11, 15, n.block[14])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[6])
+	gy(&state, 0, 5, 10, 15, n.block[5])
+	gx(&state, 1, 6, 11, 12, n.block[9])
+	gy(&state, 1, 6, 11, 12, n.block[0])
+	gx(&state, 2, 7, 8, 13, n.block[11])
+	gy(&state, 2, 7, 8, 13, n.block[15])
+	gx(&state, 3, 4, 9, 14, n.block[8])
+	gy(&state, 3, 4, 9, 14, n.block[1])
+
+	// round4
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[10])
+	gy(&state, 0, 4, 8, 12, n.block[7])
+	gx(&state, 1, 5, 9, 13, n.block[12])
+	gy(&state, 1, 5, 9, 13, n.block[9])
+	gx(&state, 2, 6, 10, 14, n.block[14])
+	gy(&state, 2, 6, 10, 14, n.block[3])
+	gx(&state, 3, 7, 11, 15, n.block[13])
+	gy(&state, 3, 7, 11, 15, n.block[15])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[4])
+	gy(&state, 0, 5, 10, 15, n.block[0])
+	gx(&state, 1, 6, 11, 12, n.block[11])
+	gy(&state, 1, 6, 11, 12, n.block[2])
+	gx(&state, 2, 7, 8, 13, n.block[5])
+	gy(&state, 2, 7, 8, 13, n.block[8])
+	gx(&state, 3, 4, 9, 14, n.block[1])
+	gy(&state, 3, 4, 9, 14, n.block[6])
+
+	// round5
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[12])
+	gy(&state, 0, 4, 8, 12, n.block[13])
+	gx(&state, 1, 5, 9, 13, n.block[9])
+	gy(&state, 1, 5, 9, 13, n.block[11])
+	gx(&state, 2, 6, 10, 14, n.block[15])
+	gy(&state, 2, 6, 10, 14, n.block[10])
+	gx(&state, 3, 7, 11, 15, n.block[14])
+	gy(&state, 3, 7, 11, 15, n.block[8])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[7])
+	gy(&state, 0, 5, 10, 15, n.block[2])
+	gx(&state, 1, 6, 11, 12, n.block[5])
+	gy(&state, 1, 6, 11, 12, n.block[3])
+	gx(&state, 2, 7, 8, 13, n.block[0])
+	gy(&state, 2, 7, 8, 13, n.block[1])
+	gx(&state, 3, 4, 9, 14, n.block[6])
+	gy(&state, 3, 4, 9, 14, n.block[4])
+
+	// round6
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[9])
+	gy(&state, 0, 4, 8, 12, n.block[14])
+	gx(&state, 1, 5, 9, 13, n.block[11])
+	gy(&state, 1, 5, 9, 13, n.block[5])
+	gx(&state, 2, 6, 10, 14, n.block[8])
+	gy(&state, 2, 6, 10, 14, n.block[12])
+	gx(&state, 3, 7, 11, 15, n.block[15])
+	gy(&state, 3, 7, 11, 15, n.block[1])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[13])
+	gy(&state, 0, 5, 10, 15, n.block[3])
+	gx(&state, 1, 6, 11, 12, n.block[0])
+	gy(&state, 1, 6, 11, 12, n.block[10])
+	gx(&state, 2, 7, 8, 13, n.block[2])
+	gy(&state, 2, 7, 8, 13, n.block[6])
+	gx(&state, 3, 4, 9, 14, n.block[4])
+	gy(&state, 3, 4, 9, 14, n.block[7])
+
+	// round7
+
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[11])
+	gy(&state, 0, 4, 8, 12, n.block[15])
+	gx(&state, 1, 5, 9, 13, n.block[5])
+	gy(&state, 1, 5, 9, 13, n.block[0])
+	gx(&state, 2, 6, 10, 14, n.block[1])
+	gy(&state, 2, 6, 10, 14, n.block[9])
+	gx(&state, 3, 7, 11, 15, n.block[8])
+	gy(&state, 3, 7, 11, 15, n.block[6])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[14])
+	gy(&state, 0, 5, 10, 15, n.block[10])
+	gx(&state, 1, 6, 11, 12, n.block[2])
+	gy(&state, 1, 6, 11, 12, n.block[12])
+	gx(&state, 2, 7, 8, 13, n.block[3])
+	gy(&state, 2, 7, 8, 13, n.block[4])
+	gx(&state, 3, 4, 9, 14, n.block[7])
+	gy(&state, 3, 4, 9, 14, n.block[13])
 
 	for i := range n.cv {
 		state[i] ^= state[i+8]

--- a/blake3.go
+++ b/blake3.go
@@ -83,8 +83,8 @@ type node struct {
 // node. When nodes are being merged into parents, only the first 8 words are
 // used. When the root node is being used to generate output, the full 16 words
 // are used.
-func (n node) compress() [16]uint32 {
-	state := [16]uint32{
+func (n node) compress() (state [16]uint32) {
+	state = [16]uint32{
 		n.cv[0], n.cv[1], n.cv[2], n.cv[3],
 		n.cv[4], n.cv[5], n.cv[6], n.cv[7],
 		iv[0], iv[1], iv[2], iv[3],
@@ -249,7 +249,7 @@ func (n node) compress() [16]uint32 {
 		state[i] ^= state[i+8]
 		state[i+8] ^= n.cv[i]
 	}
-	return state
+	return
 }
 
 // chainingValue returns the first 8 words of the compressed node. This is used

--- a/blake3.go
+++ b/blake3.go
@@ -80,115 +80,104 @@ type node struct {
 // node. When nodes are being merged into parents, only the first 8 words are
 // used. When the root node is being used to generate output, the full 16 words
 // are used.
-func (n node) compress() (s [16]uint32) {
+func (n node) compress() [16]uint32 {
 	// round1 rather than init s and mix, do both.
 	// mix the columns.
-	s[0], s[4], s[8], s[12] = g(n.cv[0], n.cv[4], iv[0], uint32(n.counter), n.block[0], n.block[1])
-	s[1], s[5], s[9], s[13] = g(n.cv[1], n.cv[5], iv[1], uint32(n.counter>>32), n.block[2], n.block[3])
-	s[2], s[6], s[10], s[14] = g(n.cv[2], n.cv[6], iv[2], n.blockLen, n.block[4], n.block[5])
-	s[3], s[7], s[11], s[15] = g(n.cv[3], n.cv[7], iv[3], n.flags, n.block[6], n.block[7])
+	s0, s4, s8, s12 := g(n.cv[0], n.cv[4], iv[0], uint32(n.counter), n.block[0], n.block[1])
+	s1, s5, s9, s13 := g(n.cv[1], n.cv[5], iv[1], uint32(n.counter>>32), n.block[2], n.block[3])
+	s2, s6, s10, s14 := g(n.cv[2], n.cv[6], iv[2], n.blockLen, n.block[4], n.block[5])
+	s3, s7, s11, s15 := g(n.cv[3], n.cv[7], iv[3], n.flags, n.block[6], n.block[7])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[8], n.block[9])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[10], n.block[11])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[12], n.block[13])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[14], n.block[15])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[8], n.block[9])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[10], n.block[11])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[12], n.block[13])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[14], n.block[15])
+	// round2
 
-	// round 2
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[2], n.block[6])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[3], n.block[10])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[7], n.block[0])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[4], n.block[13])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[2], n.block[6])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[3], n.block[10])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[7], n.block[0])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[4], n.block[13])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[1], n.block[11])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[12], n.block[5])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[9], n.block[14])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[15], n.block[8])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[1], n.block[11])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[12], n.block[5])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[9], n.block[14])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[15], n.block[8])
+	// round3
 
-	// round 3
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[3], n.block[4])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[10], n.block[12])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[13], n.block[2])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[7], n.block[14])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[3], n.block[4])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[10], n.block[12])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[13], n.block[2])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[7], n.block[14])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[6], n.block[5])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[9], n.block[0])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[11], n.block[15])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[8], n.block[1])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[6], n.block[5])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[9], n.block[0])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[11], n.block[15])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[8], n.block[1])
+	// round4
 
-	// round 4
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[10], n.block[7])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[12], n.block[9])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[14], n.block[3])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[13], n.block[15])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[10], n.block[7])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[12], n.block[9])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[14], n.block[3])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[13], n.block[15])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[4], n.block[0])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[11], n.block[2])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[5], n.block[8])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[1], n.block[6])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[4], n.block[0])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[11], n.block[2])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[5], n.block[8])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[1], n.block[6])
+	// round5
 
-	// round 5
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[12], n.block[13])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[9], n.block[11])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[15], n.block[10])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[14], n.block[8])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[12], n.block[13])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[9], n.block[11])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[15], n.block[10])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[14], n.block[8])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[7], n.block[2])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[5], n.block[3])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[0], n.block[1])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[6], n.block[4])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[7], n.block[2])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[5], n.block[3])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[0], n.block[1])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[6], n.block[4])
+	// round6
 
-	// round 6
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[9], n.block[14])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[11], n.block[5])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[8], n.block[12])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[15], n.block[1])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[9], n.block[14])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[11], n.block[5])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[8], n.block[12])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[15], n.block[1])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[13], n.block[3])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[0], n.block[10])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[2], n.block[6])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[4], n.block[7])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[13], n.block[3])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[0], n.block[10])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[2], n.block[6])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[4], n.block[7])
+	// round7
 
-	// round 7
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[11], n.block[15])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[5], n.block[0])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[1], n.block[9])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[8], n.block[6])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[11], n.block[15])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[5], n.block[0])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[1], n.block[9])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[8], n.block[6])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[14], n.block[10])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[2], n.block[12])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[3], n.block[4])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[7], n.block[13])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[14], n.block[10])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[2], n.block[12])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[3], n.block[4])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[7], n.block[13])
 
-	s[0] ^= s[0+8]
-	s[1] ^= s[1+8]
-	s[2] ^= s[2+8]
-	s[3] ^= s[3+8]
-	s[4] ^= s[4+8]
-	s[5] ^= s[5+8]
-	s[6] ^= s[6+8]
-	s[7] ^= s[7+8]
-	s[0+8] ^= n.cv[0]
-	s[1+8] ^= n.cv[1]
-	s[2+8] ^= n.cv[2]
-	s[3+8] ^= n.cv[3]
-	s[4+8] ^= n.cv[4]
-	s[5+8] ^= n.cv[5]
-	s[6+8] ^= n.cv[6]
-	s[7+8] ^= n.cv[7]
-	return
+	return [16]uint32{
+		s0 ^ s8, s1 ^ s9, s2 ^ s10, s3 ^ s11,
+		s4 ^ s12, s5 ^ s13, s6 ^ s14, s7 ^ s15,
+		s8 ^ n.cv[0], s9 ^ n.cv[1], s10 ^ n.cv[2], s11 ^ n.cv[3],
+		s12 ^ n.cv[4], s13 ^ n.cv[5], s14 ^ n.cv[6], s15 ^ n.cv[7],
+	}
 }
 
 // chainingValue returns the first 8 words of the compressed node. This is used

--- a/blake3.go
+++ b/blake3.go
@@ -80,9 +80,9 @@ type node struct {
 // node. When nodes are being merged into parents, only the first 8 words are
 // used. When the root node is being used to generate output, the full 16 words
 // are used.
-func (n node) compress() [16]uint32 {
+func (n node) compress() (state [16]uint32) {
 	// round1 rather than init s and mix, do both.
-	// mix the columns.
+	// Mix the columns.
 	s0, s4, s8, s12 := g(n.cv[0], n.cv[4], iv[0], uint32(n.counter), n.block[0], n.block[1])
 	s1, s5, s9, s13 := g(n.cv[1], n.cv[5], iv[1], uint32(n.counter>>32), n.block[2], n.block[3])
 	s2, s6, s10, s14 := g(n.cv[2], n.cv[6], iv[2], n.blockLen, n.block[4], n.block[5])
@@ -93,8 +93,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[10], n.block[11])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[12], n.block[13])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[14], n.block[15])
-	// round2
 
+	// round 2
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[2], n.block[6])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[3], n.block[10])
@@ -106,8 +106,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[12], n.block[5])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[9], n.block[14])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[15], n.block[8])
-	// round3
 
+	// round 3
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[3], n.block[4])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[10], n.block[12])
@@ -119,8 +119,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[9], n.block[0])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[11], n.block[15])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[8], n.block[1])
-	// round4
 
+	// round 4
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[10], n.block[7])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[12], n.block[9])
@@ -132,8 +132,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[11], n.block[2])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[5], n.block[8])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[1], n.block[6])
-	// round5
 
+	// round 5
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[12], n.block[13])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[9], n.block[11])
@@ -145,8 +145,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[5], n.block[3])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[0], n.block[1])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[6], n.block[4])
-	// round6
 
+	// round 6
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[9], n.block[14])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[11], n.block[5])
@@ -158,8 +158,8 @@ func (n node) compress() [16]uint32 {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[0], n.block[10])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[2], n.block[6])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[4], n.block[7])
-	// round7
 
+	// round 7
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[11], n.block[15])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[5], n.block[0])
@@ -172,12 +172,13 @@ func (n node) compress() [16]uint32 {
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[3], n.block[4])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[7], n.block[13])
 
-	return [16]uint32{
+	state = [16]uint32{
 		s0 ^ s8, s1 ^ s9, s2 ^ s10, s3 ^ s11,
 		s4 ^ s12, s5 ^ s13, s6 ^ s14, s7 ^ s15,
 		s8 ^ n.cv[0], s9 ^ n.cv[1], s10 ^ n.cv[2], s11 ^ n.cv[3],
 		s12 ^ n.cv[4], s13 ^ n.cv[5], s14 ^ n.cv[6], s15 ^ n.cv[7],
 	}
+	return
 }
 
 // chainingValue returns the first 8 words of the compressed node. This is used

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -20,9 +20,26 @@ func main() {
 	for i := range m {
 		m[i] = uint32(i)
 	}
-	for x := 1; x < 8; x++ {
-		fmt.Printf(`// round%d
-		
+
+	fmt.Printf(`	// round %d rather than init state and mix, do both.
+	// Mix the columns.
+	s0, s4, s8, s12 := g(n.cv[0], n.cv[4], iv[0], uint32(n.counter), n.block[%d], n.block[%d])
+	s1, s5, s9, s13 := g(n.cv[1], n.cv[5], iv[1], uint32(n.counter>>32), n.block[%d], n.block[%d])
+	s2, s6, s10, s14 := g(n.cv[2], n.cv[6], iv[2], n.blockLen, n.block[%d], n.block[%d])
+	s3, s7, s11, s15 := g(n.cv[3], n.cv[7], iv[3], n.flags, n.block[%d], n.block[%d])
+
+	// Mix the diagonals.
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[%d], n.block[%d])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[%d], n.block[%d])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[%d], n.block[%d])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[%d], n.block[%d])
+
+`, 1, m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
+
+	permute(&m)
+
+	for x := 2; x < 8; x++ {
+		fmt.Printf(`	// round %d
 	// Mix the columns.
 	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[%d], n.block[%d])
 	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[%d], n.block[%d])
@@ -34,6 +51,7 @@ func main() {
 	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[%d], n.block[%d])
 	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[%d], n.block[%d])
 	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[%d], n.block[%d])
+
 `, x,
 			m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
 		permute(&m)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -24,16 +24,16 @@ func main() {
 		fmt.Printf(`// round%d
 		
 	// Mix the columns.
-	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[%d], n.block[%d])
-	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[%d], n.block[%d])
-	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[%d], n.block[%d])
-	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[%d], n.block[%d])
+	s0, s4, s8, s12 = g(s0, s4, s8, s12, n.block[%d], n.block[%d])
+	s1, s5, s9, s13 = g(s1, s5, s9, s13, n.block[%d], n.block[%d])
+	s2, s6, s10, s14 = g(s2, s6, s10, s14, n.block[%d], n.block[%d])
+	s3, s7, s11, s15 = g(s3, s7, s11, s15, n.block[%d], n.block[%d])
 
 	// Mix the diagonals.
-	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[%d], n.block[%d])
-	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[%d], n.block[%d])
-	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[%d], n.block[%d])
-	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[%d], n.block[%d])
+	s0, s5, s10, s15 = g(s0, s5, s10, s15, n.block[%d], n.block[%d])
+	s1, s6, s11, s12 = g(s1, s6, s11, s12, n.block[%d], n.block[%d])
+	s2, s7, s8, s13 = g(s2, s7, s8, s13, n.block[%d], n.block[%d])
+	s3, s4, s9, s14 = g(s3, s4, s9, s14, n.block[%d], n.block[%d])
 `, x,
 			m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
 		permute(&m)

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -24,26 +24,18 @@ func main() {
 		fmt.Printf(`// round%d
 		
 	// Mix the columns.
-	gx(&state, 0, 4, 8, 12, n.block[%d])
-	gy(&state, 0, 4, 8, 12, n.block[%d])
-	gx(&state, 1, 5, 9, 13, n.block[%d])
-	gy(&state, 1, 5, 9, 13, n.block[%d])
-	gx(&state, 2, 6, 10, 14, n.block[%d])
-	gy(&state, 2, 6, 10, 14, n.block[%d])
-	gx(&state, 3, 7, 11, 15, n.block[%d])
-	gy(&state, 3, 7, 11, 15, n.block[%d])
+	s[0], s[4], s[8], s[12] = g(s[0], s[4], s[8], s[12], n.block[%d], n.block[%d])
+	s[1], s[5], s[9], s[13] = g(s[1], s[5], s[9], s[13], n.block[%d], n.block[%d])
+	s[2], s[6], s[10], s[14] = g(s[2], s[6], s[10], s[14], n.block[%d], n.block[%d])
+	s[3], s[7], s[11], s[15] = g(s[3], s[7], s[11], s[15], n.block[%d], n.block[%d])
 
 	// Mix the diagonals.
-	gx(&state, 0, 5, 10, 15, n.block[%d])
-	gy(&state, 0, 5, 10, 15, n.block[%d])
-	gx(&state, 1, 6, 11, 12, n.block[%d])
-	gy(&state, 1, 6, 11, 12, n.block[%d])
-	gx(&state, 2, 7, 8, 13, n.block[%d])
-	gy(&state, 2, 7, 8, 13, n.block[%d])
-	gx(&state, 3, 4, 9, 14, n.block[%d])
-	gy(&state, 3, 4, 9, 14, n.block[%d])
-
-`, x, m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
+	s[0], s[5], s[10], s[15] = g(s[0], s[5], s[10], s[15], n.block[%d], n.block[%d])
+	s[1], s[6], s[11], s[12] = g(s[1], s[6], s[11], s[12], n.block[%d], n.block[%d])
+	s[2], s[7], s[8], s[13] = g(s[2], s[7], s[8], s[13], n.block[%d], n.block[%d])
+	s[3], s[4], s[9], s[14] = g(s[3], s[4], s[9], s[14], n.block[%d], n.block[%d])
+`, x,
+			m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
 		permute(&m)
 	}
 }

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+)
+
+func permute(m *[16]uint32) {
+	*m = [16]uint32{
+		m[2], m[6], m[3], m[10],
+		m[7], m[0], m[4], m[13],
+		m[1], m[11], m[12], m[5],
+		m[9], m[14], m[15], m[8],
+	}
+}
+
+func main() {
+
+	var m [16]uint32
+
+	for i := range m {
+		m[i] = uint32(i)
+	}
+	for x := 1; x < 8; x++ {
+		fmt.Printf(`// round%d
+		
+	// Mix the columns.
+	gx(&state, 0, 4, 8, 12, n.block[%d])
+	gy(&state, 0, 4, 8, 12, n.block[%d])
+	gx(&state, 1, 5, 9, 13, n.block[%d])
+	gy(&state, 1, 5, 9, 13, n.block[%d])
+	gx(&state, 2, 6, 10, 14, n.block[%d])
+	gy(&state, 2, 6, 10, 14, n.block[%d])
+	gx(&state, 3, 7, 11, 15, n.block[%d])
+	gy(&state, 3, 7, 11, 15, n.block[%d])
+
+	// Mix the diagonals.
+	gx(&state, 0, 5, 10, 15, n.block[%d])
+	gy(&state, 0, 5, 10, 15, n.block[%d])
+	gx(&state, 1, 6, 11, 12, n.block[%d])
+	gy(&state, 1, 6, 11, 12, n.block[%d])
+	gx(&state, 2, 7, 8, 13, n.block[%d])
+	gy(&state, 2, 7, 8, 13, n.block[%d])
+	gx(&state, 3, 4, 9, 14, n.block[%d])
+	gy(&state, 3, 4, 9, 14, n.block[%d])
+
+`, x, m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15])
+		permute(&m)
+	}
+}


### PR DESCRIPTION
 * Factors out the need for permute(), by generating code for each round.
 * g() inlines when pass the values instead of an array pointer and indices. This allows putting state across 16 variables instead of [16]uint32 which then causes the compiler to use more registers.

```
name      old time/op    new time/op    delta
Write-4     6.18ns ± 0%    3.41ns ± 0%  -44.93%  (p=0.000 n=9+10)
Sum256-4    6.21µs ± 0%    3.51µs ± 0%  -43.43%  (p=0.000 n=9+9)
XOF-4       5.73ns ± 0%    3.13ns ± 0%  -45.36%  (p=0.000 n=9+10)

name      old speed      new speed      delta
Write-4    162MB/s ± 0%   294MB/s ± 0%  +81.53%  (p=0.000 n=9+10)
XOF-4      174MB/s ± 0%   319MB/s ± 0%  +83.04%  (p=0.000 n=9+10)

name      old alloc/op   new alloc/op   delta
Write-4      0.00B          0.00B          ~     (all equal)
Sum256-4     0.00B          0.00B          ~     (all equal)
XOF-4        0.00B          0.00B          ~     (all equal)

name      old allocs/op  new allocs/op  delta
Write-4       0.00           0.00          ~     (all equal)
Sum256-4      0.00           0.00          ~     (all equal)
XOF-4         0.00           0.00          ~     (all equal)
```