### PR TITLE
[performance] Store temporary hashers in a pool

### DIFF
--- a/blake3_test.go
+++ b/blake3_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -195,10 +196,16 @@ func BenchmarkWrite(b *testing.B) {
 }
 
 func BenchmarkSum256(b *testing.B) {
-	b.ReportAllocs()
-	buf := make([]byte, 1024)
-	for i := 0; i < b.N; i++ {
-		blake3.Sum256(buf)
+	for _, blockSize := range []int64{1, 4, 8, 16, 32, 1024} {
+		b.Run(fmt.Sprintf("blockSize%d", blockSize), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(blockSize)
+			buf := make([]byte, blockSize)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blake3.Sum256(buf)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
To reduce `Hasher` initialization cost in Sum256 and Sum512 it was used a pool to store `*Hasher` instances.

Result:

```
name                    old time/op    new time/op    delta
Sum256/blockSize1-8        314ns ± 1%     253ns ± 1%  -19.40%  (p=0.008 n=5+5)
Sum256/blockSize4-8        313ns ± 1%     249ns ± 2%  -20.42%  (p=0.008 n=5+5)
Sum256/blockSize8-8        315ns ± 1%     251ns ± 2%  -20.32%  (p=0.008 n=5+5)
Sum256/blockSize16-8       310ns ± 1%     242ns ± 4%  -21.76%  (p=0.008 n=5+5)
Sum256/blockSize32-8       309ns ± 1%     244ns ± 4%  -21.20%  (p=0.008 n=5+5)
Sum256/blockSize1024-8    2.40µs ± 0%    2.32µs ± 1%   -3.30%  (p=0.008 n=5+5)

name                    old speed      new speed      delta
Sum256/blockSize1-8     3.18MB/s ± 1%  3.95MB/s ± 1%  +23.99%  (p=0.008 n=5+5)
Sum256/blockSize4-8     12.8MB/s ± 1%  16.0MB/s ± 2%  +25.66%  (p=0.008 n=5+5)
Sum256/blockSize8-8     25.4MB/s ± 1%  31.8MB/s ± 2%  +25.37%  (p=0.008 n=5+5)
Sum256/blockSize16-8    51.6MB/s ± 1%  66.0MB/s ± 3%  +27.88%  (p=0.008 n=5+5)
Sum256/blockSize32-8     103MB/s ± 1%   131MB/s ± 4%  +27.00%  (p=0.008 n=5+5)
Sum256/blockSize1024-8   428MB/s ± 0%   442MB/s ± 1%   +3.42%  (p=0.008 n=5+5)
```