### PR TITLE
Parallel Write and XOF

### DIFF
--- a/blake3.go
+++ b/blake3.go
@@ -2,12 +2,14 @@
 package blake3 // import "lukechampine.com/blake3"
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"hash"
 	"io"
 	"math"
 	"math/bits"
+	"sync"
 
 	"lukechampine.com/blake3/bao"
 	"lukechampine.com/blake3/guts"
@@ -20,10 +22,10 @@ type Hasher struct {
 	size  int // output size, for Sum
 
 	// log(n) set of Merkle subtree roots, at most one per height.
-	stack   [64 - (guts.MaxSIMD + 10)][8]uint32 // 10 = log2(guts.ChunkSize)
-	counter uint64                              // number of buffers hashed; also serves as a bit vector indicating which stack elems are occupied
+	stack   [64][8]uint32
+	counter uint64 // number of buffers hashed; also serves as a bit vector indicating which stack elems are occupied
 
-	buf    [guts.MaxSIMD * guts.ChunkSize]byte
+	buf    [guts.ChunkSize]byte
 	buflen int
 }
 
@@ -31,21 +33,21 @@ func (h *Hasher) hasSubtreeAtHeight(i int) bool {
 	return h.counter&(1<<i) != 0
 }
 
-func (h *Hasher) pushSubtree(cv [8]uint32) {
+func (h *Hasher) pushSubtree(cv [8]uint32, height int) {
 	// seek to first open stack slot, merging subtrees as we go
-	i := 0
+	i := height
 	for h.hasSubtreeAtHeight(i) {
 		cv = guts.ChainingValue(guts.ParentNode(h.stack[i], cv, &h.key, h.flags))
 		i++
 	}
 	h.stack[i] = cv
-	h.counter++
+	h.counter += 1 << height
 }
 
 // rootNode computes the root of the Merkle tree. It does not modify the
 // stack.
 func (h *Hasher) rootNode() guts.Node {
-	n := guts.CompressBuffer(&h.buf, h.buflen, &h.key, h.counter*guts.MaxSIMD, h.flags)
+	n := guts.CompressChunk(h.buf[:h.buflen], &h.key, h.counter, h.flags)
 	for i := bits.TrailingZeros64(h.counter); i < bits.Len64(h.counter); i++ {
 		if h.hasSubtreeAtHeight(i) {
 			n = guts.ParentNode(h.stack[i], guts.ChainingValue(n), &h.key, h.flags)
@@ -58,16 +60,49 @@ func (h *Hasher) rootNode() guts.Node {
 // Write implements hash.Hash.
 func (h *Hasher) Write(p []byte) (int, error) {
 	lenp := len(p)
-	for len(p) > 0 {
-		if h.buflen == len(h.buf) {
-			n := guts.CompressBuffer(&h.buf, h.buflen, &h.key, h.counter*guts.MaxSIMD, h.flags)
-			h.pushSubtree(guts.ChainingValue(n))
-			h.buflen = 0
-		}
+
+	// align to chunk boundary
+	if h.buflen > 0 {
 		n := copy(h.buf[h.buflen:], p)
 		h.buflen += n
 		p = p[n:]
 	}
+	if h.buflen == len(h.buf) {
+		n := guts.CompressChunk(h.buf[:], &h.key, h.counter, h.flags)
+		h.pushSubtree(guts.ChainingValue(n), 0)
+		h.buflen = 0
+	}
+
+	// process full chunks
+	if len(p) > len(h.buf) {
+		rem := len(p) % len(h.buf)
+		if rem == 0 {
+			rem = len(h.buf) // don't prematurely compress
+		}
+		eigenbuf := bytes.NewBuffer(p[:len(p)-rem])
+		trees := guts.Eigentrees(h.counter, uint64(eigenbuf.Len()/guts.ChunkSize))
+		cvs := make([][8]uint32, len(trees))
+		counter := h.counter
+		var wg sync.WaitGroup
+		for i, height := range trees {
+			wg.Add(1)
+			go func(i int, buf []byte, counter uint64) {
+				defer wg.Done()
+				cvs[i] = guts.ChainingValue(guts.CompressEigentree(buf, &h.key, counter, h.flags))
+			}(i, eigenbuf.Next((1<<height)*guts.ChunkSize), counter)
+			counter += 1 << height
+		}
+		wg.Wait()
+		for i, height := range trees {
+			h.pushSubtree(cvs[i], height)
+		}
+		p = p[len(p)-rem:]
+	}
+
+	// buffer remaining partial chunk
+	n := copy(h.buf[h.buflen:], p)
+	h.buflen += n
+
 	return lenp, nil
 }
 

--- a/blake3_test.go
+++ b/blake3_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"lukechampine.com/blake3"
+	"lukechampine.com/blake3/guts"
 )
 
 func toHex(data []byte) string { return hex.EncodeToString(data) }
@@ -184,6 +185,21 @@ func TestReset(t *testing.T) {
 	}
 }
 
+func TestEigentrees(t *testing.T) {
+	for i := uint64(0); i < 64; i++ {
+		for j := uint64(0); j < 64; j++ {
+			trees := guts.Eigentrees(i, j)
+			x := i
+			for _, tree := range trees {
+				x += 1 << tree
+			}
+			if x != i+j {
+				t.Errorf("Wrong eigentrees for %v, %v: %v", i, j, trees)
+			}
+		}
+	}
+}
+
 type nopReader struct{}
 
 func (nopReader) Read(p []byte) (int, error) { return len(p), nil }
@@ -221,6 +237,14 @@ func BenchmarkSum256(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(65536)
 		buf := make([]byte, 65536)
+		for i := 0; i < b.N; i++ {
+			blake3.Sum256(buf)
+		}
+	})
+	b.Run("1048576", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(16 * 65536)
+		buf := make([]byte, 16*65536)
 		for i := 0; i < b.N; i++ {
 			blake3.Sum256(buf)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module lukechampine.com/blake3
 
-go 1.17
+go 1.22
 
 require github.com/klauspost/cpuid/v2 v2.0.9

--- a/guts/compress_amd64.go
+++ b/guts/compress_amd64.go
@@ -1,6 +1,8 @@
 package guts
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 //go:generate go run avo/gen.go -out blake3_amd64.s
 

--- a/guts/compress_noasm.go
+++ b/guts/compress_noasm.go
@@ -3,7 +3,9 @@
 
 package guts
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 // CompressBuffer compresses up to MaxSIMD chunks in parallel and returns their
 // root node.


### PR DESCRIPTION
Adds `guts.CompressEigentree` for concurrently compressing 2^n buffers. `Write` also spawns a goroutines for each eigentree. This should get us close to full CPU load for large inputs.

Also parallelizes XOF while we're at it, because why not.

@glycerine, would you mind running `go test -bench=.`? I don't have access to an AVX-512 machine at the moment and I'm curious about the improvement here.