### PR TITLE
Fix split writes producing different output

### DIFF
--- a/blake3.go
+++ b/blake3.go
@@ -68,7 +68,7 @@ func (h *Hasher) Write(p []byte) (int, error) {
 		h.buflen += n
 		p = p[n:]
 	}
-	if h.buflen == len(h.buf) {
+	if h.buflen == len(h.buf) && len(p) > 0 {
 		n := guts.CompressChunk(h.buf[:], &h.key, h.counter, h.flags)
 		h.pushSubtree(guts.ChainingValue(n), 0)
 		h.buflen = 0

--- a/blake3_test.go
+++ b/blake3_test.go
@@ -219,6 +219,22 @@ func TestEigentrees(t *testing.T) {
 	}
 }
 
+func TestSplitWrite(t *testing.T) {
+	in := make([]byte, 2048)
+	for i := range in {
+		in[i] = byte(i)
+	}
+	exp := blake3.Sum256(in)
+	for i := range in {
+		h := blake3.New(32, nil)
+		h.Write(in[:i])
+		h.Write(in[i:])
+		if !bytes.Equal(h.Sum(nil), exp[:]) {
+			t.Fatalf("split write failed at position %v", i)
+		}
+	}
+}
+
 type nopReader struct{}
 
 func (nopReader) Read(p []byte) (int, error) { return len(p), nil }

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module lukechampine.com/blake3
 go 1.22
 
 require github.com/klauspost/cpuid/v2 v2.0.9
+
+retract v1.4.0 // https://github.com/lukechampine/blake3/pull/26


### PR DESCRIPTION
#25 introduced a bug: If the Hasher's buffer is partially full, and the next write would align to a chunk boundary, the buffer would be consumed greedily instead of sticking around until the `Sum` call. For certain inputs, this caused `Sum` to produce different results depending on how the input was split between `Writes`.

`v1.4.0`, the buggy version, has been retracted. If you were affected, please reach out and I'll do what I can to help.

Thanks to @Josh-Walker-GM for finding and responsibly disclosing this bug.